### PR TITLE
JZ - add index page

### DIFF
--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
+
+export default function MenuItemReviewIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const {
+    data: menuItemReviews,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/menuitemreview/all"],
+    { url: "/api/menuitemreview/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/menuitemreview/create"
+          style={{ float: "right" }}
+        >
+          Create Menu Item Review
+        </Button>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        {createButton()}
+        <h1>Menu Item Reviews</h1>
+        <MenuItemReviewTable
+          menuItemReviews={menuItemReviews}
+          currentUser={currentUser}
+        />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/MenuItemReview/MenuItemReviewIndexPage.stories.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import { http, HttpResponse } from "msw";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+
+export default {
+  title: "pages/MenuItemReview/MenuItemReviewIndexPage",
+  component: MenuItemReviewIndexPage,
+};
+
+const Template = () => <MenuItemReviewIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews, {
+        status: 200,
+      });
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/menuitemreview/all", () => {
+      return HttpResponse.json(menuItemReviewFixtures.threeReviews, {
+        status: 200,
+      });
+    }),
+    http.delete("/api/menuitemreview", () => {
+      return HttpResponse.json({ message: "ok" }, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
@@ -1,0 +1,246 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import AxiosMockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import mockConsole from "tests/testutils/mockConsole";
+
+import React from "react";
+vi.mock("main/components/OurTable", () => {
+  function OurTable({ data, columns, testid = "testid" }) {
+    return (
+      <table data-testid={testid}>
+        <tbody>
+          {data.map((row, ri) => (
+            <tr key={ri} data-testid={`${testid}-row-${ri}`}>
+              {columns.map((col, ci) => {
+                const colId = col.accessorKey || col.id;
+                const value = col.accessorKey ? row[col.accessorKey] : null;
+                const cellTestId = `${testid}-cell-row-${ri}-col-${colId}`;
+                if (col.cell) {
+                  const ctx = {
+                    row: { index: ri, original: row, getValue: () => value },
+                    column: { id: colId },
+                    cell: {},
+                  };
+                  return (
+                    <td key={ci} data-testid={cellTestId}>
+                      {col.cell(ctx)}
+                    </td>
+                  );
+                }
+                return (
+                  <td key={ci} data-testid={cellTestId}>
+                    {value != null ? String(value) : ""}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+  function ButtonColumn(label, _variant, callback, testIdPrefix) {
+    return {
+      id: label,
+      header: label,
+      cell: ({ row, column }) => (
+        <button
+          data-testid={`${testIdPrefix}-cell-row-${row.index}-col-${column.id}-button`}
+          onClick={() => callback({ row })}
+        >
+          {label}
+        </button>
+      ),
+    };
+  }
+  return { default: OurTable, ButtonColumn };
+});
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    toast: { success: (x) => mockToast(x) },
+  };
+});
+
+describe("MenuItemReviewIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "MenuItemReviewTable";
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const renderPage = () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Create Menu Item Review/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Menu Item Review/);
+    expect(button).toHaveAttribute("href", "/menuitemreview/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three reviews correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    expect(
+      screen.queryByText("Create Menu Item Review"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    axiosMock.onGet("/api/menuitemreview/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error?.mock?.calls?.[0]?.[0];
+    if (errorMessage) {
+      expect(errorMessage).toMatch(
+        "Error communicating with backend via GET on /api/menuitemreview/all",
+      );
+    }
+
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+    axiosMock
+      .onGet("/api/menuitemreview/all")
+      .reply(200, menuItemReviewFixtures.threeReviews);
+    axiosMock.onDelete("/api/menuitemreview").reply(200, { message: "ok" });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    const firstId = Number(
+      screen.getByTestId(`${testId}-cell-row-0-col-id`).textContent,
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "MenuItemReview deleted successfully",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/menuitemreview");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: firstId });
+  });
+
+  test("uses GET method to fetch reviews (kills method mutation)", async () => {
+    setupUserOnly();
+
+    axiosMock.onAny("/api/menuitemreview/all").reply((config) => {
+      if ((config.method ?? "").toUpperCase() !== "GET") {
+        return [405, { error: "Method Not Allowed" }];
+      }
+      return [200, menuItemReviewFixtures.threeReviews];
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    expect(axiosMock.history.post.length).toBe(0);
+    expect(axiosMock.history.put.length).toBe(0);
+    expect(axiosMock.history.delete.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Summary:

Add MenuItemReviewIndexPage wired to /menuitemreview

Shows table of all reviews for any logged-in user

Admins see buttons for Create, Edit, and Delete

Delete calls DELETE /api/menuitemreview?id= and shows toast

Added Storybook stories: Empty, ThreeItemsOrdinaryUser, ThreeItemsAdminUser

Added tests for rendering, backend timeout, and delete functionality

Lint + mutation tests passed

Screenshots:
<img width="1470" height="883" alt="image" src="https://github.com/user-attachments/assets/f9264049-0d30-412b-9479-2cf678bc0b60" />
<img width="1470" height="830" alt="image" src="https://github.com/user-attachments/assets/07b21eec-b563-4729-9261-8f2953216174" />
<img width="1470" height="876" alt="image" src="https://github.com/user-attachments/assets/55481c00-8e13-4a79-98bd-91fe138de1b6" />

Storybook link:
http://localhost:6006/?path=/story/pages-menuitemreview-menuitemreviewindexpage--three-items-ordinary-user

How to test:
start backend
mvn -ntp spring-boot:run
start frontend
npm start
run only these tests
npm test -- src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.jsx
run mutation tests
npx stryker run --mutate "src/main/pages/MenuItemReview/MenuItemReviewIndexPage.jsx" --reporters clear-text --vitest.enableFindRelatedTests false
Closed https://github.com/ucsb-cs156-f25/team02-f25-07/issues/41